### PR TITLE
Fixed composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
 
-        "phpoffice/phpexcel": "dev-develop"
+        "phpoffice/phpexcel": "~1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Installation via composer (as it is described in README) currently fails due to the fact that `"phpoffice/phpexcel": "dev-develop"` has stability `dev` now and composer rquires stability `stable` by default
